### PR TITLE
[STYLE] 온라인 전시회 감상평 CSS

### DIFF
--- a/src/main/resources/mapper/exhibition_reviewMapper.xml
+++ b/src/main/resources/mapper/exhibition_reviewMapper.xml
@@ -9,7 +9,7 @@
 	</insert>
 	
 	<select id="select_ExhibitionReviewList" resultType="ExhibitionReviewVO">
-		select e.exhibition_no, e.no, e.member_no, e.content, m.nickname, date_format(e.write_date, "%y.%m.%d") write_date
+		select e.exhibition_no, e.no, e.member_no, e.content, m.nickname, date_format(e.write_date, "%Y.%m.%d") write_date
 		from exhibition_reply e join member m on e.member_no = m.no where e.exhibition_no = ${exhibition_no}
 		order by exhibition_no desc
 	</select>

--- a/src/main/webapp/WEB-INF/views/online_exhibition/onlineList.jsp
+++ b/src/main/webapp/WEB-INF/views/online_exhibition/onlineList.jsp
@@ -114,19 +114,20 @@ $(function(){
 					
 					let body = "<ul>";
 					sucResult.each(function(idx,obj){
-						body += "<li><div><span>"+obj.nickname+"  (" + obj.write_date + ")</span>"
+						body += "<li class='ex_review_wrap'><div class='ex_reivew_coment'><p>"+obj.nickname+"</p><span>"+ obj.write_date + "</span>"
+						body += "<em>" +obj.content+ "</em>"
 						if(obj.member_no == ${logNo}){
-							body += "<span><input type='button' class='btn' value='수정'>";
+							body += "<div><input type='button' class='btn' value='수정'>";
 							body += "<input type='button' class='btn' value='삭제' title="+obj.no+","+ obj.member_no+">";
 						}
-						body += "<br/>" +obj.content+ "</span></div>"
+						body += "<br/></div></div>"
 						
 						if(obj.nickname == "${logNickname}"){
-							body += "<div style='display:none'><form method='post'>";
+							body += "<div style='display:none' class='ex_edit'><form method='post'>";
 							body += "<input type='hidden' name='member_no' value="+obj.member_no+">";
 							body += "<input type='hidden' name='no' value="+obj.no+">";
-							body += "<textarea name='content'>"+obj.content+"</textarea>";
-							body += "<input type='submit' class='btn' value='수정하기'></form></div>";
+							body += "<textarea name='content' class='ex_edit_txt'>"+obj.content+"</textarea>";
+							body += "<input type='submit' class='ex_edit_btn' value='수정하기'></form></div>";
 						}
 						body += "<hr/></li>";
 					});
@@ -405,17 +406,21 @@ $(function(){
 	    		</li>
    				</c:forEach>
    				<li id="ex_review">
-   					<h4>감상평</h4>
-					<form method="post" id="ex_reviewForm">
-					<input type="hidden" name="exhibition_no" id="exhibition_no" value="${exhibition.no}">
-					<div id="ex_review_box">
-						<textarea name="content" id="ex_reviewComent" class="ex_reivewComent" placeholder="내용을 입력하세요"></textarea>
-						<span id="ex_reviewBtn"><input type="submit" id="ex_reviewInsert" value="댓글 등록"/></span>
-					</div>
-					</form>
+   					<h4>&nbsp;&nbsp;감상평</h4>
+   					<span id="review_close">▼</span>
+   					<span id="review_open">▲</span>
 				</li>
 				<!-- 댓글 목록 표시 -->
-				<li id="ex_reviewList" style="background-color:red"></li>
+				<li id="ex_reviewList"></li>
+	    		<li id="ex_reviewForm_wrap">
+		    		<form method="post" id="ex_reviewForm">
+						<input type="hidden" name="exhibition_no" id="exhibition_no" value="${exhibition.no}">
+						<div id="ex_review_box">
+							<textarea name="content" id="ex_reviewComent" class="ex_reivewComent" placeholder="내용을 입력하세요"></textarea>
+							<span id="ex_reviewBtn"><input type="submit" id="ex_reviewInsert" value="등록"/></span>
+						</div>
+					</form>
+	    		</li>
 	    	</ul>
 	    	<i class="fa-solid fa-xmark"></i>
     	</div>

--- a/src/main/webapp/css/exhibition/onlineList.css
+++ b/src/main/webapp/css/exhibition/onlineList.css
@@ -504,7 +504,7 @@ audio::-webkit-media-controls-panel {
 	background-color: orange;
 	border-radius:5px;	
 }
-#ex_detail_wrap > ul > li {
+#ex_detail_wrap > ul > li:not(#ex_review, #ex_reviewList, #ex_reviewForm_wrap) {
 	width:100%; height:600px;
 	display:block;
 	padding:20px 0 10px 0;
@@ -591,4 +591,98 @@ audio::-webkit-media-controls-panel {
 
 /* 이미지 상세 모달 - end */
 
-#table_container {height:500px}
+/* 감상평 - start */
+#ex_review {height:90px; display:table; position:relative}
+#ex_review > h4 {
+	width:1030px;
+	font-size:2.4rem;
+	padding:20px;
+	line-height:50px;
+	letter-spacing:5px;
+	font-weight:bold;
+}
+#ex_review > h4::after {
+	content:"";
+	width:100%;
+	border-bottom:2px solid #999;
+	display:block;
+}
+#ex_review > span {
+	position:absolute; right:50px; top:30px;
+	font-size:2rem;
+	line-height:50px;
+	cursor:pointer
+}
+#ex_reviewList {padding:0 20px; font-size:1.8rem}
+.ex_review_wrap{line-height:25px;}
+.ex_reivew_coment {
+	width:100%;
+	min-height:80px; height:auto;
+	padding:10px 0;
+	position:relative;
+}
+.ex_review_wrap > .ex_reivew_coment > p { /* 닉네임 */
+	width:200px;
+	position:absolute; left:50px; top:10px;
+}
+.ex_review_wrap > .ex_reivew_coment > span { /* 날짜 */
+	width:200px;
+	display:block;
+	position:absolute; left:50px; bottom:10px;
+	font-size:1.6rem; color:#999;
+} 
+.ex_review_wrap > .ex_reivew_coment > em { /* 감상평 */
+	width:610px;
+	display:block;
+	font-style: normal;
+	margin-left:270px;
+	white-space:pre-wrap;
+}
+.ex_review_wrap > .ex_reivew_coment > div { /* 수정/삭제 */
+	position:absolute; right:50px; bottom:10px;
+}
+.ex_review_wrap > .ex_reivew_coment > div > input {
+	border:none;
+	background-color:transparent;
+	cursor:pointer;
+	color:#999
+}
+#ex_reviewForm_wrap {height:120px; padding: 20px 50px}
+#ex_review_box > textarea {
+	resize:none;
+	width:835px; height:100px; 
+	border: 2px solid #c0c0c0;
+	border-radius:10px;
+	padding:0 10px;
+	line-height:25px;
+	float:left;
+	margin-right:20px
+}
+#ex_reviewBtn {float:left}
+#ex_reviewBtn > input {
+	width:80px; height:104px;
+	border: none;
+	border-radius:10px;
+	cursor:pointer;
+	background-color:#b4b4b4
+}
+
+.ex_edit_txt {
+	resize:none;
+	width:815px; height:100px; 
+	border: 2px solid #c0c0c0;
+	border-radius:10px;
+	padding:0 10px;
+	margin-left:40px
+}
+.ex_edit_btn {
+	width:80px; height:104px;
+	border: none;
+	border-radius:10px;
+	cursor:pointer;
+	background-color:#b4b4b4;
+	float:right;
+	margin-right:50px
+}
+/* 감상평 - end */
+

--- a/src/main/webapp/js/online_exhibition.js
+++ b/src/main/webapp/js/online_exhibition.js
@@ -94,6 +94,7 @@ $(document).ready(function(){
 
 /* 작품보기 - 모달 띄우기*/
 $(document).ready(function(){
+	$("#ex_detail_bg").css({"display" : "block"});
 	$(".workView_btn").click(function(){
 		$("#ex_detail_bg").css({"display" : "block"});
 		$('footer').css({"display" : "none"});
@@ -191,15 +192,17 @@ function pagination(){
 	}
 }	
 
-/* 오디오 연속 재생 */
-function nextPlay(){
-
-document.getElementById('audio_player').src = "/img/exhibition/audio/𝗙. 𝗖𝗵𝗼𝗽𝗶𝗻 - Nocturne Op.9 No.2 in E flat Major.mp3"; 
-
-var media = document.getElementById('audio_player');
-
-media.currentTime = 0;
-
-media.play();
-
-}
+/* 감상평 열기/닫기 */
+$(document).ready(function(){
+	$('#review_close').css({"display":"none"});
+	$('#review_open').click(function(){
+		$('#review_close').css({"display":"block"});
+		$('#review_open').css({"display":"none"});
+		$('#ex_reviewList').css({"display":"none"});
+	})
+	$('#review_close').click(function(){
+		$('#review_open').css({"display":"block"});
+		$('#review_close').css({"display":"none"});
+		$('#ex_reviewList').css({"display":"block"});
+	})
+})


### PR DESCRIPTION
### Issue 타입(하나 이상의 Issue 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 
feature/online_exhibition -> develop

### 변경 사항 ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 온라인 전시회 감상평 CSS
- 댓글 등록이 아래에 있어서 감상평을 접었다 폈다 할 수 있도록 구현했습니다.
- close #80 

### 테스트 결과 ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
- 
![image](https://user-images.githubusercontent.com/96978871/169571159-8cc9353d-050c-419f-b3e3-5dc9c48b7464.png)
![image](https://user-images.githubusercontent.com/96978871/169571195-3a4d3631-2332-4108-8665-a6d4c7ff3c8a.png)
