### PR TITLE
[FEAT] 온라인 리스트 감상평 수정

### DIFF
--- a/src/main/webapp/WEB-INF/views/online_exhibition/onlineList.jsp
+++ b/src/main/webapp/WEB-INF/views/online_exhibition/onlineList.jsp
@@ -207,21 +207,20 @@ $(function(){
 			});
 		}
 		// 댓글 등록하기
-		$(document).on('submit',"#ex_reviewForm", function(exhibition_no){
+		$(document).on('submit',"#ex_reviewForm", function(){
 			//event.preventDefault();
-	
 			if($("#ex_reviewComent").val()==""){ // 댓글 입력 안함
 				alert("댓글을 입력 후에 등록해주세요");
 			}else{ // 댓글 입력
 				let data = $("#ex_reviewForm").serialize(); // form데이터 보내기
+				var exhibition_no = $("#exhibition_no").val();
 				$.ajax({
 					url :'/ex_review/writeOk',
 					data : data,
 					type : 'POST',
 					success : function(result){
 						$("#ex_reviewComent").val("");
-						select_ExhibitionReviewList(result);
-						console.log(result);
+						select_ExhibitionReviewList(exhibition_no);
 					},error : function(e){
 						alert("로그인 후 이용해주세요");
 					}
@@ -240,6 +239,7 @@ $(function(){
 		// 수정하기 DB연결
 		$(document).on('submit','#ex_reviewList form',function(){
 			event.preventDefault();
+			var exhibition_no = $("#exhibition_no").val();
 			console.log($("#exhibition_no").val());
 			$.ajax({
 				url:'/ex_review/editOk',
@@ -256,7 +256,7 @@ $(function(){
 	
 		// 댓글 삭제하기 
 		$(document).on('click', "#ex_reviewList input[value=삭제]", function(){
-			
+			var exhibition_no = $("#exhibition_no").val();
 			if(confirm('댓글을 삭제하시겠어요?')){
 				let ex_reviewData = $(this).attr("title").split(",");
 				let data = "exhibition_no="+ex_reviewData[0]+"&member_no="+ex_reviewData[1];


### PR DESCRIPTION
### Issue 타입(하나 이상의 Issue 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 
feature/online_exhibition -> develop

### 변경 사항 ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 온라인 리스트 페이징, 작품 불러오기 코드 수정에 따라 감상평 코드도 조금 수정되었습니다.
- close #80 

### 테스트 결과 ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

- 댓글 리스트가 한 번씩 안불러와지는 현상이 있습니다.